### PR TITLE
Retain comments and linebreaks when writting new yaml

### DIFF
--- a/lib/src/update_version.dart
+++ b/lib/src/update_version.dart
@@ -2,8 +2,8 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:args/command_runner.dart';
+import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
-import 'package:pubspec/pubspec.dart';
 import 'package:pubspec_version/src/console.dart';
 
 abstract class UpdateVersion extends Command {
@@ -13,10 +13,43 @@ abstract class UpdateVersion extends Command {
 
   Future run() async {
     final dir = Directory(globalResults['pubspec-dir']);
-    final pubSpec = await PubSpec.load(dir);
-    final version = nextVersion(pubSpec.version);
-    await pubSpec.copy(version: version).save(dir);
-    console.log(version.toString());
+    final File pubSpec = File(p.join(dir.path, "pubspec.yaml"));
+
+    List<String> lines = pubSpec.readAsLinesSync();
+    String versionStringUnformatted =
+        lines.firstWhere((l) => l.startsWith("version: "), orElse: () => null);
+    if (versionStringUnformatted == null) {
+      throw new StateError("No version found!");
+    }
+
+    String versionString = _extractVersion(versionStringUnformatted);
+    Version oldVersion = Version.parse(versionString);
+    Version newVersion = nextVersion(oldVersion);
+    console.log(newVersion.toString());
+
+    return _writeNewPubSpec(pubSpec, oldVersion, newVersion);
+  }
+
+  Future _writeNewPubSpec(
+      File pubSpec, Version oldVersion, Version newVersion) {
+    String newPubSpec = pubSpec.readAsStringSync().replaceFirst(
+        'version: "${oldVersion}"', "version: " + '"${newVersion.toString()}"');
+    final ioSink = pubSpec.openWrite();
+
+    try {
+      ioSink.write(newPubSpec);
+    } finally {
+      return ioSink.close();
+    }
+  }
+
+  String _extractVersion(String versionStringUnformatted) {
+    String versionString = versionStringUnformatted
+        .replaceAll('"', "")
+        .split("version: ")
+        .skip(1)
+        .first;
+    return versionString;
   }
 
   Version nextVersion(Version v);

--- a/lib/src/update_version.dart
+++ b/lib/src/update_version.dart
@@ -27,14 +27,16 @@ abstract class UpdateVersion extends Command {
     Version newVersion = nextVersion(oldVersion);
     console.log(newVersion.toString());
 
-    return _writeNewPubSpec(pubSpec, oldVersion, newVersion);
+    _writeNewPubSpec(pubSpec, oldVersion, newVersion);
   }
 
   Future _writeNewPubSpec(
-      File pubSpec, Version oldVersion, Version newVersion) {
+      File pubSpec, Version oldVersion, Version newVersion) async {
     String newPubSpec = pubSpec.readAsStringSync().replaceFirst(
         'version: "${oldVersion}"', "version: " + '"${newVersion.toString()}"');
-    final ioSink = pubSpec.openWrite();
+
+    final ioSink =
+        await File(p.join(pubSpec.parent.path, 'pubspec.yaml')).openWrite();
 
     try {
       ioSink.write(newPubSpec);

--- a/lib/src/update_version.dart
+++ b/lib/src/update_version.dart
@@ -5,6 +5,7 @@ import 'package:args/command_runner.dart';
 import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:pubspec_version/src/console.dart';
+import 'package:pubspec_version/src/version_extractor.dart';
 
 abstract class UpdateVersion extends Command {
   final Console console;
@@ -15,15 +16,7 @@ abstract class UpdateVersion extends Command {
     final dir = Directory(globalResults['pubspec-dir']);
     final File pubSpec = File(p.join(dir.path, "pubspec.yaml"));
 
-    List<String> lines = pubSpec.readAsLinesSync();
-    String versionStringUnformatted =
-        lines.firstWhere((l) => l.startsWith("version: "), orElse: () => null);
-    if (versionStringUnformatted == null) {
-      throw new StateError("No version found!");
-    }
-
-    String versionString = _extractVersion(versionStringUnformatted);
-    Version oldVersion = Version.parse(versionString);
+    Version oldVersion = VersionExtractor.extractVersion(pubSpec);
     Version newVersion = nextVersion(oldVersion);
     console.log(newVersion.toString());
 
@@ -43,15 +36,6 @@ abstract class UpdateVersion extends Command {
     } finally {
       return ioSink.close();
     }
-  }
-
-  String _extractVersion(String versionStringUnformatted) {
-    String versionString = versionStringUnformatted
-        .replaceAll('"', "")
-        .split("version: ")
-        .skip(1)
-        .first;
-    return versionString;
   }
 
   Version nextVersion(Version v);

--- a/lib/src/version_extractor.dart
+++ b/lib/src/version_extractor.dart
@@ -3,10 +3,13 @@ import 'dart:io';
 import 'package:pub_semver/pub_semver.dart';
 
 abstract class VersionExtractor {
+  static const String VERSION_REGEX = "version:.+?[^#](?=[^('|\")]*(?:(\"|')[^('|\")]*('|\")[^('|\")]*)*\$)";
+
   static Version extractVersion(File pubSpec) {
-    List<String> lines = pubSpec.readAsLinesSync();
-    String versionStringUnformatted =
-        lines.firstWhere((l) => l.startsWith("version: "), orElse: () => null);
+    RegExp versionMatch = RegExp(VERSION_REGEX);
+    String lines = pubSpec.readAsStringSync();
+    String versionStringUnformatted = versionMatch.firstMatch(lines)?.group(0);
+
     if (versionStringUnformatted == null) {
       throw new StateError("No version found!");
     }

--- a/lib/src/version_extractor.dart
+++ b/lib/src/version_extractor.dart
@@ -3,7 +3,8 @@ import 'dart:io';
 import 'package:pub_semver/pub_semver.dart';
 
 abstract class VersionExtractor {
-  static const String VERSION_REGEX = "version:.+?[^#](?=[^('|\")]*(?:(\"|')[^('|\")]*('|\")[^('|\")]*)*\$)";
+  static const String VERSION_REGEX =
+      "version:.+?[^#](?=[^('|\")]*(?:(\"|')[^('|\")]*('|\")[^('|\")]*)*\$)";
 
   static Version extractVersion(File pubSpec) {
     RegExp versionMatch = RegExp(VERSION_REGEX);

--- a/lib/src/version_extractor.dart
+++ b/lib/src/version_extractor.dart
@@ -1,0 +1,27 @@
+import 'dart:io';
+
+import 'package:pub_semver/pub_semver.dart';
+
+abstract class VersionExtractor {
+  static Version extractVersion(File pubSpec) {
+    List<String> lines = pubSpec.readAsLinesSync();
+    String versionStringUnformatted =
+        lines.firstWhere((l) => l.startsWith("version: "), orElse: () => null);
+    if (versionStringUnformatted == null) {
+      throw new StateError("No version found!");
+    }
+
+    String versionString = _extractVersion(versionStringUnformatted);
+    Version oldVersion = Version.parse(versionString);
+    return oldVersion;
+  }
+
+  static String _extractVersion(String versionStringUnformatted) {
+    String versionString = versionStringUnformatted
+        .replaceAll('"', "")
+        .split("version: ")
+        .skip(1)
+        .first;
+    return versionString;
+  }
+}

--- a/test/functional_test.dart
+++ b/test/functional_test.dart
@@ -88,6 +88,6 @@ void main() {
     expect(code, 0);
     await expectVersion('0.4.0');
     List<String> pubSpec = File("${temp.path}/pubspec.yaml").readAsLinesSync();
-    expect(pubSpec[1], "");
+    expect(pubSpec[3], "");
   });
 }

--- a/test/functional_test.dart
+++ b/test/functional_test.dart
@@ -9,6 +9,7 @@ class MockConsole extends Mock implements Console {}
 
 void main() {
   Directory temp;
+  File tempPubSpec;
   MockConsole mockConsole;
   Application app;
 
@@ -19,7 +20,8 @@ void main() {
 
   setUp(() async {
     temp = await Directory.systemTemp.createTemp();
-    File('test/pubspec_sample.yaml').copy('${temp.path}/pubspec.yaml');
+    tempPubSpec = await File('test/pubspec_sample.yaml')
+        .copy('${temp.path}/pubspec.yaml');
     mockConsole = MockConsole();
     app = Application(mockConsole);
   });
@@ -69,5 +71,25 @@ void main() {
     final code = await app.run(['get', '-d', temp.path]);
     expect(code, 0);
     await expectVersion('0.3.2');
+  });
+
+  test('bump breaking and retain comments', () async {
+    final code = await app.run(['bump', 'breaking', '-d', temp.path]);
+    expect(code, 0);
+    await expectVersion('0.4.0');
+
+    expect(
+        File("${temp.path}/pubspec.yaml")
+            .readAsStringSync()
+            .contains("#This is a test comment"),
+        true);
+  });
+
+  test('bump breaking and retain linebreaks', () async {
+    final code = await app.run(['bump', 'breaking', '-d', temp.path]);
+    expect(code, 0);
+    await expectVersion('0.4.0');
+    String pubSpecString = File("${temp.path}/pubspec.yaml").readAsStringSync();
+    expect(pubSpecString.contains("\r\n\r\n"), true);
   });
 }

--- a/test/functional_test.dart
+++ b/test/functional_test.dart
@@ -9,7 +9,6 @@ class MockConsole extends Mock implements Console {}
 
 void main() {
   Directory temp;
-  File tempPubSpec;
   MockConsole mockConsole;
   Application app;
 
@@ -20,8 +19,7 @@ void main() {
 
   setUp(() async {
     temp = await Directory.systemTemp.createTemp();
-    tempPubSpec = await File('test/pubspec_sample.yaml')
-        .copy('${temp.path}/pubspec.yaml');
+    await File('test/pubspec_sample.yaml').copy('${temp.path}/pubspec.yaml');
     mockConsole = MockConsole();
     app = Application(mockConsole);
   });

--- a/test/functional_test.dart
+++ b/test/functional_test.dart
@@ -87,7 +87,7 @@ void main() {
     final code = await app.run(['bump', 'breaking', '-d', temp.path]);
     expect(code, 0);
     await expectVersion('0.4.0');
-    String pubSpecString = File("${temp.path}/pubspec.yaml").readAsStringSync();
-    expect(pubSpecString.contains("\r\n\r\n"), true);
+    List<String> pubSpec = File("${temp.path}/pubspec.yaml").readAsLinesSync();
+    expect(pubSpec[1], "");
   });
 }

--- a/test/pubspec_sample.yaml
+++ b/test/pubspec_sample.yaml
@@ -1,5 +1,7 @@
 description: "A CLI tool to set/bump the `version` key in pubspec.yaml."
+
 name: "pubspec_version"
+#This is a test comment
 version: "0.3.2"
 dependencies:
   args: "^1.5.0"

--- a/test/pubspec_sample.yaml
+++ b/test/pubspec_sample.yaml
@@ -1,8 +1,10 @@
-description: "A CLI tool to set/bump the `version` key in pubspec.yaml."
+description: "A CLI tool to set/bump the `version` key in pubspec.yaml.
+version: 1.2.3
+is for testing"
 
 name: "pubspec_version"
 #This is a test comment
-version: "0.3.2"
+version: "0.3.2" # parse me
 dependencies:
   args: "^1.5.0"
   pub_semver: "^1.4.2"


### PR DESCRIPTION
Resolves #17 by parsing and updating version in place.